### PR TITLE
Fix a couple of printf formatting warnings in logging

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -664,7 +664,7 @@ static void fts_backend_xapian_expunge(struct xapian_fts_backend *backend, const
 		d = xfe.did[i];
 		u = xfe.uid[i];
 
-		if(verbose>0) i_info("FTS Xapian: Deleting terms for expunged UID=%d (Docid=%d) (%s)",u,d,reason);
+		if(verbose>0) i_info("FTS Xapian: Deleting terms for expunged UID=%ld (Docid=%d) (%s)",u,d,reason);
 		try
 		{
 			backend->dbw->delete_document(d);
@@ -945,7 +945,9 @@ bool fts_backend_xapian_index_hdr(Xapian::WritableDatabase * dbx, uint uid, cons
 	}
 	catch(Xapian::Error e)
 	{
-		i_error("FTS Xapian: fts_backend_xapian_index_hdr (%s) -> %s",field,data);
+		std::string s;
+		data->toUTF8String(s);
+		i_error("FTS Xapian: fts_backend_xapian_index_hdr (%s) -> %s",field,s.c_str());
 		i_error("FTS Xapian: %s",e.get_msg().c_str());
 	}
 	return false;


### PR DESCRIPTION
These popped up when compiling with clang.

The first one (using `%ld` for the `long uid`) is probably architecture/ABI related (`sizeof long` sometimes equals `sizeof int`).

The second one related to treating the icu::UnicodeString as a `char *`. This seemed a bit more worrying, but I'm not familiar with icu, so perhaps there's an operator override I missed on my version (66.1) that makes this work for you.

In any case the explicit conversion in pull request seems to work.