### PR TITLE
commit when last commit was too long ago

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -525,16 +525,21 @@ static int fts_backend_xapian_hold(struct xapian_fts_backend * backend, const ch
 	char *zErrMsg = 0;
         struct stat sb;
 
+	struct timeval tp;
+	long dt;
+	dt = tp.tv_sec * 1000 + tp.tv_usec / 1000;
+
+	gettimeofday(&tp, NULL);
+
 	backend->guid = NULL;
 	backend->db = NULL;
 	backend->nb_updates=0;
+	backend->last_commit_dt=dt;
 	backend->boxname = NULL;
 	backend->db_expunge = NULL;
 
 	/* Performance calculator*/
-	struct timeval tp;
-	gettimeofday(&tp, NULL);
-	backend->perf_dt = tp.tv_sec * 1000 + tp.tv_usec / 1000;
+	backend->perf_dt = dt;
 	backend->perf_uid=0;
 	backend->perf_nb=0;
 	backend->perf_pt=0;
@@ -608,11 +613,13 @@ static void fts_backend_xapian_commit(struct xapian_fts_backend *backend, const 
                 delete(backend->dbw);
                 backend->dbw=NULL;
 		backend->nb_updates=0;
+		struct timeval tp;
+		gettimeofday(&tp, NULL);
+		long edt = tp.tv_sec * 1000 + tp.tv_usec / 1000;
+		backend->last_commit_dt = edt;
 		if(verbose>0)
 		{
-			gettimeofday(&tp, NULL);
-			dt = tp.tv_sec * 1000 + tp.tv_usec / 1000 - dt;
-			i_info("FTS Xapian: Committed '%s' in %ld ms",reason,dt);
+			i_info("FTS Xapian: Committed '%s' in %ld ms",reason,edt - dt);
 		}
         }
 }


### PR DESCRIPTION
When indexing mail with unusually long headers, indexing becomes slow
and memory hungry. Indexing such emails by batch of 1000 ends up eating
all the memory, and the index process is killed. The next time indexing
is triggered, all the work is lost so no progress can be done.

This patch enforces a commit every 5 minutes. This ensures that even
if only 36 emails (real number) are indexed in the meantime, and the
process is killed afterwards because memory usage is high, progress can
be done.

About the choice of 5 minutes: commit time will be negligible when this
triggers.  In my workload, I saw both cases where the number of
update and the time were the limiting factor triggering the commit.