### PR TITLE
FIX: fts_backend_xapian_lookup_multi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+/stamp-h2
+/stamp.h
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+/libtool
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+
+# Generated Makefile 
+# (meta build system like autotools, 
+# can automatically generate from config.status script
+# (which is called by configure script))
+Makefile
+
+/dummy-config.h
+/dummy-config.h.in
+/fts-xapian-config.h
+/run-test.sh
+
+src/*.o
+src/*.lo
+src/*.la
+
+src/.libs/**

--- a/src/fts-backend-xapian.cpp
+++ b/src/fts-backend-xapian.cpp
@@ -725,7 +725,7 @@ static int fts_backend_xapian_lookup(struct fts_backend *_backend, struct mailbo
 	return 0;
 }
 
-static int fts_backend_xapian_lookup_multi (struct fts_backend *_backend, struct mailbox *const boxes[], struct mail_search_arg *args, enum fts_lookup_flags flags, struct fts_multi_result *result)
+static int fts_backend_xapian_lookup_multi(struct fts_backend *_backend, struct mailbox *const boxes[], struct mail_search_arg *args, enum fts_lookup_flags flags, struct fts_multi_result *result)
 {
 	if(verbose>0) i_info("FTS Xapian: fts_backend_xapian_lookup_multi");
 
@@ -741,8 +741,12 @@ static int fts_backend_xapian_lookup_multi (struct fts_backend *_backend, struct
 	{
 		box_result = array_append_space(&box_results);
 		box_result->box = boxes[i];
-		if(fts_backend_xapian_lookup(_backend, boxes[i], args, flags, box_result)<1) return -1;
+		if(fts_backend_xapian_lookup(_backend, boxes[i], args, flags, box_result)<0) return -1;
 	}
+
+	array_append_zero(&box_results);
+	result->box_results = array_front_modifiable(&box_results);
+
 	return 0;
 }
 


### PR DESCRIPTION
1. The error handling check against `fts_backend_xapian_lookup` was wrong which resulted in returning always an error.

2. `fts_backend_xapian_lookup_multi` did not pass the collected results on to the dovecot FTS backend. Thus dovecot virual folder search did not work and produced the following IMAP error:
`xx NO [SERVERBUG] Internal error occurred. Refer to server log for more information`