### PR TITLE
feature: systemd service/timer to optimise FTS index

### DIFF
--- a/contrib/systemd/dovecot-fts-optimize.service.in
+++ b/contrib/systemd/dovecot-fts-optimize.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Optimize Dovecot FTS Index
+Requires=dovecot.service
+After=dovecot.service
+
+[Service]
+Type=oneshot
+ExecStart=@@prefix@@/doveadm fts optimize -A
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/dovecot-fts-optimize.timer.in
+++ b/contrib/systemd/dovecot-fts-optimize.timer.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Optimize Dovecot FTS Index
+
+[Timer]
+OnCalendar=@@index_frequency@@
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Hi!

I use this regularly. Was wondering if you'd like these systemd service/timer templates.

They have two variables in them:
* `prefix` - distribution prefix differs (`/usr/bin`, `/usr/local/bin` and so on)
* `index_frequency` - how often the FTS index should be indexed. This can be set using systemd specific syntax ([systemd.timer.5](https://man.archlinux.org/man/systemd.timer.5.en), [systemd.time.7](https://man.archlinux.org/man/systemd.time.7.en) for details), e.g. `daily` for daily run.