### PR TITLE
fix sentinel missing warning when compiling against dovecot 3.15

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -868,7 +868,7 @@ static int fts_backend_xapian_set_path(struct xapian_fts_backend *backend)
 	const char * path = mailbox_list_get_root_forced(ns->list, MAILBOX_LIST_PATH_TYPE_INDEX);
 
 	if(backend->path != NULL) i_free(backend->path);
-	backend->path = i_strconcat(path, "/" XAPIAN_FILE_PREFIX, NULL);
+	backend->path = i_strconcat(path, "/" XAPIAN_FILE_PREFIX, static_cast<const char*>(NULL));
 
 	if(verbose>0) i_info("FTS Xapian: Index path = %s",backend->path);
 


### PR DESCRIPTION
Without it I get:
```
In file included from fts-backend-xapian.cpp:64:
322fts-backend-xapian-functions.cpp: In function 'int fts_backend_xapian_set_path(xapian_fts_backend*)':
323fts-backend-xapian-functions.cpp:871:64: warning: missing sentinel in function call [-Wformat=]
324  871 |  backend->path = i_strconcat(path, "/" XAPIAN_FILE_PREFIX, NULL);
325      |                                                                ^
```