### PR TITLE
Update dovecot-fts-xapian.spec

### DIFF
--- a/PACKAGES/RPM/dovecot-fts-xapian.spec
+++ b/PACKAGES/RPM/dovecot-fts-xapian.spec
@@ -9,7 +9,7 @@ Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  xapian-core-devel, libicu-devel, dovecot-devel
 BuildRequires:  gcc, gcc-c++
-BuildRequires:  automake, autoconf, libtool
+BuildRequires:  make, automake, autoconf, libtool
 Requires:       xapian-core, dovecot
 
 %description


### PR DESCRIPTION
Package `make` is also required. Otherwise you will get error like this:

```
...
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.4RGhBy
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd fts-xapian-1.4.10a
+ /usr/bin/make
/var/tmp/rpm-tmp.4RGhBy: line 34: /usr/bin/make: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.4RGhBy (%build)
```