### PR TITLE
fix unused variable warning

### DIFF
--- a/src/fts-backend-xapian.cpp
+++ b/src/fts-backend-xapian.cpp
@@ -64,6 +64,8 @@ static struct fts_backend *fts_backend_xapian_alloc(void)
 
 static int fts_backend_xapian_init(struct fts_backend *_backend, const char **error_r)
 {
+	(void)error_r;
+
 	struct xapian_fts_backend *backend = (struct xapian_fts_backend *)_backend;
 
 	backend->db = NULL;


### PR DESCRIPTION
warnings in C are evil