### PR TITLE
Fix lowmemory option parsing

### DIFF
--- a/src/fts-xapian-plugin.c
+++ b/src/fts-xapian-plugin.c
@@ -80,7 +80,7 @@ static void fts_xapian_mail_user_created(struct mail_user *user)
                 	}
                 	else if (strncmp(*tmp,"lowmemory=",10)==0)
                 	{
-                	        len=atol(*tmp + 9);
+                	        len=atol(*tmp + 10);
                 	        if(len>0) { fuser->set.lowmemory = len; }
                 	}
                 	else if (strncmp(*tmp,"attachments=",12)==0)


### PR DESCRIPTION
Hi,
The parsing of the lowmemory option is broken because of on off-by-one error.
This simple patch fixes it.