### PR TITLE
Fix OpenBSD support

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -506,10 +506,15 @@ static long fts_backend_xapian_current_time()
 static long fts_backend_xapian_get_free_memory() // KB
 {
 	struct rlimit rl;
+
+#if !defined(__OpenBSD__)
 	getrlimit(RLIMIT_AS,&rl);
 
 	long limit = rl.rlim_cur / 1024.0;
 	if(fts_xapian_settings.verbose>1) i_warning("FTS Xapian: RLIM AS =%ld",limit);
+#else
+	long limit = 0;
+#endif
 
 	getrlimit(RLIMIT_DATA,&rl);
 	long l2 = rl.rlim_cur / 1024.0;
@@ -517,7 +522,7 @@ static long fts_backend_xapian_get_free_memory() // KB
 
 	if((l2>0) && ((limit>l2) || (limit<1))) limit=l2;
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)	
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)	
 	uint32_t m;
 	size_t len = sizeof(m);
 	sysctlbyname("vm.stats.vm.v_free_count", &m, &len, NULL, 0);

--- a/src/fts-xapian-plugin.c
+++ b/src/fts-xapian-plugin.c
@@ -35,7 +35,7 @@ static void fts_xapian_mail_user_created(struct mail_user *user)
         fuser->set.partial 	= XAPIAN_DEFAULT_PARTIAL;
         fuser->set.full 	= XAPIAN_DEFAULT_FULL;
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 	size_t len = sizeof(fuser->set.pagesize);
 	sysctlbyname("hw.pagesize", &(fuser->set.pagesize), &len, NULL, 0);
 #else

--- a/src/fts-xapian-plugin.h
+++ b/src/fts-xapian-plugin.h
@@ -16,7 +16,7 @@
 #include "module-context.h"
 #include "fts-api-private.h"
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #if !defined(__APPLE__)


### PR DESCRIPTION
1.5.0 added some changes that broke OpenBSD support. OpenBSD does not have an
rlimit for address space nor `sysctlbyname`.

---

Tested on OpenBSD 7.1 with Dovecot 2.3.18