### PR TITLE
Add needed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ First install the following packages, or equivalent for your operating system.
 ```
 Ubuntu:
 apt-get build-dep dovecot-core 
-apt-get install dovecot-dev git libxapian-dev libicu-dev libsqlite3-dev
+apt-get install dovecot-dev git libxapian-dev libicu-dev libsqlite3-dev libtool pkg-config valgrind 
 
 Archlinux:
 pacman -S dovecot


### PR DESCRIPTION
Coming from a minimal Ubuntu 22.04_1 + iRedMail install, I had to install these three additional packages to configure / make fts-xapian without errors