### PR TITLE
Fix warning/crash in latest.

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -724,7 +724,7 @@ static void fts_backend_xapian_commitclose(Xapian::WritableDatabase * db, long n
 	delete(db);
 	if(fts_xapian_settings.verbose>0)
 	{
-        	if(err) { i_info("%s : Could not commit this time, but will do a bit later"); }
+        	if(err) { i_info("%s : Could not commit this time, but will do a bit later",title->c_str()); }
 		else i_info("%s : Done in %ld ms by %s",title->c_str(),fts_backend_xapian_current_time()-t,cuserid(NULL));
 	}
 	if(strcmp(cuserid(NULL),"root")==0) fts_backend_xapian_ownership(dbpath);


### PR DESCRIPTION
Fix warning about missing arg in printf format string.

I think this is causing crashes in latest.

> Feb 11 12:30:09 myhostname dovecot: indexer-worker(USER3)<10124><wjzjACEEyWWJJwAA0J78UA:oZY8ByEEyWWMJwAA0J78UA>: FTS Xapian: fts_backend_xapian_release (update_deinit) - done
> Feb 11 12:30:09 myhostname kernel: traps: indexer-worker[10127] general protection fault ip:7efec2cf4c82 sp:7efebfd69bf0 error:0
> Feb 11 12:30:09 myhostname kernel:  in libdovecot.so.0.0.0[7efec2c2f000+10e000] likely on CPU 0 (core 0, socket 0)
> Feb 11 12:30:09 myhostname kernel:  in libdovecot.so.0.0.0[7efec2c2f000+10e000]
> Feb 11 12:30:09 myhostname kernel: 
> Feb 11 12:30:09 myhostname dovecot: indexer-worker(USER3)<10124><wjzjACEEyWWJJwAA0J78UA:oZY8ByEEyWWMJwAA0J78UA>: Fatal: master: service(indexer-worker): child 10124 killed with signal 11 (core dumps disabled - https://dovecot.org/bugreport.html#coredumps)
