### PR TITLE
fix printf format warning

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -1061,7 +1061,7 @@ bool fts_backend_xapian_index(struct xapian_fts_backend *backend, const char* fi
 		{
 			backend->doc = new Xapian::Document();
 			backend->doc->add_value(1,Xapian::sortable_serialise(backend->lastuid));
-			u = i_strdup_printf("Q%d",backend->lastuid);
+			u = i_strdup_printf("Q%ld",(long)(backend->lastuid));
 			backend->doc->add_term(u);
 			i_free(u);
 		}


### PR DESCRIPTION
fix printf format warning

```
In file included from fts-backend-xapian.cpp:56:
fts-backend-xapian-functions.cpp: In function 'bool fts_backend_xapian_index(xapian_fts_backend*, const char*, icu::UnicodeString*)':
fts-backend-xapian-functions.cpp:1064:48: warning: format '%d' expects argument of type 'int', but argument 2 has type 'long int' [-Wformat=]
 1064 |                         u = i_strdup_printf("Q%d",backend->lastuid);   
      |                                               ~^  ~~~~~~~~~~~~~~~~
      |                                                |           |
      |                                                int         long int
      |                                               %ld
```