### PR TITLE
Fix warning in printf format

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -1036,7 +1036,7 @@ static void fts_backend_xapian_build_qs(XQuerySet * qs, struct mail_search_arg *
 
 bool fts_backend_xapian_index(struct xapian_fts_backend *backend, const char* field, icu::UnicodeString* data)
 {
-	if(fts_xapian_settings.verbose>1) i_info("FTS Xapian: fts_backend_xapian_index %s : %ld",field,data->length());
+	if(fts_xapian_settings.verbose>1) i_info("FTS Xapian: fts_backend_xapian_index %s : %ld",field,(long)(data->length()));
 
 	if(data->length()<fts_xapian_settings.partial) return true;
 


### PR DESCRIPTION
Fix warning in printf format

```
In file included from fts-backend-xapian.cpp:57:
fts-backend-xapian-functions.cpp: In function 'bool fts_backend_xapian_index(xapian_fts_backend*, const char*, icu::UnicodeString*)':
fts-backend-xapian-functions.cpp:1039:95: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'int32_t' {aka 'int'} [-Wformat=]
 1039 | bose>1) i_info("FTS Xapian: fts_backend_xapian_index %s : %ld",field,data->length());
      |                                                           ~~^        ~~~~~~~~~~~~~~
      |                                                             |                    |
      |                                                             long int             int32_t {aka int}
      |                                                           %d

```