### PR TITLE
fix printf format warnings

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -623,7 +623,7 @@ class XDoc
 
 		while((j=headers->size())>0)
 		{
-			if(verbose>0) syslog(LOG_INFO,"%s %s : Populate %ld / %ld Header=%s TextLength=%ld",title,getSummary().c_str(),j,k,headers->at(j-1)->c_str(),strings->at(j-1)->length());
+			if(verbose>0) syslog(LOG_INFO,"%s %s : Populate %ld / %ld Header=%s TextLength=%ld",title,getSummary().c_str(),j,k,headers->at(j-1)->c_str(),(long)strings->at(j-1)->length());
 			ngram = new XNGram(headers->at(j-1),&data,&stems,title,verbose);
 			ngram->add(strings->at(j-1));
 			delete(ngram);

--- a/src/fts-backend-xapian.cpp
+++ b/src/fts-backend-xapian.cpp
@@ -108,7 +108,7 @@ static int fts_backend_xapian_init(struct fts_backend *_backend, const char **er
 
 	openlog("xapian-docswriter",0,LOG_MAIL);
 
-        if(fts_xapian_settings.verbose>0) i_info("FTS Xapian: Starting with partial=%ld full=%ld verbose=%d lowmemory=%ld MB vs freemem=%ld MB", fts_xapian_settings.partial,fts_xapian_settings.full,fts_xapian_settings.verbose,fts_xapian_settings.lowmemory, long(fts_backend_xapian_get_free_memory()/1024.0));
+        if(fts_xapian_settings.verbose>0) i_info("FTS Xapian: Starting with partial=%ld full=%ld verbose=%ld lowmemory=%ld MB vs freemem=%ld MB", fts_xapian_settings.partial,fts_xapian_settings.full,fts_xapian_settings.verbose,fts_xapian_settings.lowmemory, long(fts_backend_xapian_get_free_memory()/1024.0));
 
 	return 0;
 }
@@ -232,7 +232,7 @@ static void fts_backend_xapian_update_expunge(struct fts_backend_update_context 
 	else
 	{
 		char * u = i_strdup_printf("replace into docs values (%d)",uid);
-		if(fts_xapian_settings.verbose>0) i_info("FTS Xapian : Expunged %ld on %s",uid,backend->expdb);
+		if(fts_xapian_settings.verbose>0) i_info("FTS Xapian : Expunged %d on %s",uid,backend->expdb);
 		if(sqlite3_exec(expdb,u,NULL,0,&zErrMsg) != SQLITE_OK)
 		{
 			i_error("FTS Xapian: Expunging (3) UID=%d : Can not add UID : %s",uid,zErrMsg);


### PR DESCRIPTION
Fix some logging format warnings.

```
libtool: compile:  x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -O2 -I/usr/include/dovecot -DFTS_MAIL_USER_INIT_THREE_ARGS=1 -O2 -O2 -pipe -mtune=generic -std=gnu99 -c fts-xapian-plugin.c -o fts-xapian-plugin.o >/dev/null 2>&1
In file included from fts-backend-xapian.cpp:69:
fts-backend-xapian-functions.cpp: In member function 'void XDoc::populate_stems(long int, const char*)':
fts-backend-xapian-functions.cpp:626:106: warning: format '%ld' expects argument of type 'long int', but argument 8 has type 'int32_t' {aka 'int'} [-Wformat=]
  626 |                    if(verbose>0) syslog(LOG_INFO,"%s %s : Populate %ld / %ld Header=%s TextLength=%ld",title,getSummary().c_str(),j,k,headers->at(j-1)->c_str(),strings->at(j-1)->length());
      |                                                                                                   ~~^                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                     |                                                                                   |
      |                                                                                                     long int                                                                            int32_t {aka int}
      |                                                                                                   %d
fts-backend-xapian.cpp: In function 'int fts_backend_xapian_init(fts_backend*, const char**)':
fts-backend-xapian.cpp:111:107: warning: format '%d' expects argument of type 'int', but argument 4 has type 'long int' [-Wformat=]
  111 |   if(fts_xapian_settings.verbose>0) i_info("FTS Xapian: Starting with partial=%ld full=%ld verbose=%d lowmemory=%ld MB vs freemem=%ld MB", fts_xapian_settings.partial,fts_xapian_settings.full,fts_xapian_settings.verbose,fts_xapian_settings.lowmemory, long(fts_ba
ckend_xapian_get_free_memory()/1024.0));
      |                                                                                                    ~^                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                     |                                                                                                               |
      |                                                                                                     int                                                                                                             long int
      |                                                                                                    %ld
fts-backend-xapian.cpp: In function 'void fts_backend_xapian_update_expunge(fts_backend_update_context*, uint32_t)':
fts-backend-xapian.cpp:235:83: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'uint32_t' {aka 'unsigned int'} [-Wformat=]
  235 |                 if(fts_xapian_settings.verbose>0) i_info("FTS Xapian : Expunged %ld on %s",uid,backend->expdb);
      |                                                                                 ~~^        ~~~
      |                                                                                   |        |
      |                                                                                   long int uint32_t {aka unsigned int}
      |                                                                                 %d

```