### PR TITLE
reduce base64 testing log spam

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -383,7 +383,7 @@ class XNGram
 		{
 			ok=std::regex_match(s, base64Regex);
 		}
-		if(ok) syslog(LOG_INFO,"Testing Base64 (%s) -> %ld",s.c_str(),(long)ok);
+		if(ok && (verbose>0)) syslog(LOG_INFO,"Testing Base64 (%s) -> %ld",s.c_str(),(long)ok);
 		return ok;
 	}
 


### PR DESCRIPTION
I've been getting a bunch of these in my logs:

```
Apr  1 11:01:11 myhostname xapian-docswriter[21489]: Testing Base64 (bahymhuzlacryippxoukhmkmxceqohkateyyopbsqewdzpbqejfbxabuhqlldvutejijhsfoqfjhbrzhztbmcpnbqwacmuxkvkugzythnhotsrzirppbzpsyigglnawlqjllrxxhyxkebxwnvwlacjjgyizpjlrfdmuwwisvnyywazcnyxktncmmzjgxsoadwznqyukhklawejscyugkmjxrwmkliwnjendrijrsxjfhlhaiiobsmnxfqlzakdqxaweodzqhiztwbvcezohkeppzswbadgwpscrgtmqjxptkvxwumlzayamebbejznumagpxurvfgpvsrsuaeeixmoxnugfyxiskgfbrbbezixhyxbqnkwabntevdfmfjfxmaluklehjgjszrmxsldbdlasvwdwoiviwqyuoikrmlspikbfscjaraknnsjgzssgoucevylbfznthxawjselqnidbrrzqarwgevgvndjptducsnvzhovcolizylcnenxgoajfeyikpwpcczjpelswtidjfvfdhtkyazwutfrpprjrumlodwmjjmtitcprrshwwakrogevupsynitzedkuaqukqycfwmkbmfpwmupdjrwpanltjowfgnpentctlfpvjunbjvnudaavtobfyculgbjszjcotmalaavgisiyuxkxbykawmjurrjbwourpavmuzybofqjgqcwrsqlmtcgrmqxlsqfffstpjszlwkeogwylvjvvvtadepsaobnklylzpvsdfeaoxdqwogtbqwbzycamywgdsor) -> 1
```

I presume this was meant to be hidden behind the verbose setting.