### PR TITLE
Add index for Content-Type

### DIFF
--- a/src/fts-xapian-plugin.h
+++ b/src/fts-xapian-plugin.h
@@ -38,9 +38,9 @@
 
 #define XAPIAN_MAX_SEC_WAIT 15L
 
-#define HDRS_NB 10
-static const char * hdrs_emails[HDRS_NB] = { "uid", "subject", "from", "to",  "cc",  "bcc",  "messageid", "listid", "body", ""  };
-static const char * hdrs_xapian[HDRS_NB] = { "Q",   "S",       "A",    "XTO", "XCC", "XBCC", "XMID",      "XLIST",  "XBDY", "XBDY" };
+#define HDRS_NB 11
+static const char * hdrs_emails[HDRS_NB] = { "uid", "subject", "from", "to",  "cc",  "bcc",  "messageid", "listid", "body", "",     "contenttype" };
+static const char * hdrs_xapian[HDRS_NB] = { "Q",   "S",       "A",    "XTO", "XCC", "XBCC", "XMID",      "XLIST",  "XBDY", "XBDY", "XCT" };
 static const char * createTable = "CREATE TABLE IF NOT EXISTS docs(ID INT PRIMARY KEY NOT NULL);";
 static const char * selectUIDs = "select ID from docs;";
 #define CHAR_KEY "_"


### PR DESCRIPTION
This Header is used by many mail clients to search for mails with attachments.

Fixes https://github.com/grosjo/fts-xapian/issues/161