### PR TITLE
fix printf arg order warning

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -903,7 +903,7 @@ class XDocsWriter
                                 }
                                 catch(Xapian::Error e)
                                 {
-                                        syslog(LOG_WARNING,"%sCan't add document1 (%ld) : %s - %s %s",pos,title,e.get_type(),e.get_msg().c_str(),e.get_error_string());
+                                        syslog(LOG_WARNING,"%sCan't add document1 (%ld) : %s - %s %s",title,pos,e.get_type(),e.get_msg().c_str(),e.get_error_string());
                                         err=true;
 					err_s.append(e.get_type());
                                 }


### PR DESCRIPTION
fix printf arg order warning:

```
In file included from fts-backend-xapian.cpp:70:
fts-backend-xapian-functions.cpp: In member function 'void XDocsWriter::worker()':
fts-backend-xapian-functions.cpp:906:62: warning: format '%s' expects argument of type 'char*', but argument 3 has type 'long int' [-Wformat=]
  906 |                                         syslog(LOG_WARNING,"%sCan't add document1 (%ld) : %s - %s %s",pos,title,e.get_type(),e.get_msg().c_str(),e.get_error_string());
      |                                                             ~^                                        ~~~
      |                                                              |                                        |
      |                                                              char*                                    long int
      |                                                             %ld
fts-backend-xapian-functions.cpp:906:86: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'char*' [-Wformat=]
  906 |                                         syslog(LOG_WARNING,"%sCan't add document1 (%ld) : %s - %s %s",pos,title,e.get_type(),e.get_msg().c_str(),e.get_error_string());
      |                                                                                    ~~^                    ~~~~~
      |                                                                                      |                    |
      |                                                                                      long int             char*
      |                                                                                    %s
```