### PR TITLE
Fix printf warning

### DIFF
--- a/src/fts-backend-xapian.cpp
+++ b/src/fts-backend-xapian.cpp
@@ -542,7 +542,7 @@ static int fts_backend_xapian_optimize(struct fts_backend *_backend)
 						}
 						i_free(u);
 					}
-					if(fts_xapian_settings.verbose>0) i_info("FTS Xapian: Optimize - Closing DB %s",s);
+					if(fts_xapian_settings.verbose>0) i_info("FTS Xapian: Optimize - Closing DB %s",s.c_str());
 					fts_backend_xapian_close_db(db,s.c_str(),"fts_optimize",fts_xapian_settings.verbose);
 				}
 				catch(Xapian::Error e)


### PR DESCRIPTION
`%s` requires `str.c_str()`

```
-backend-xapian.cpp: In function 'int fts_backend_xapian_optimize(fts_backend*)':
fts-backend-xapian.cpp:545:118: warning: format '%s' expects argument of type 'char*', but argument 2 has type 'std::string' {aka 'std::__cxx11::basic_string<char>'} [-Wformat=]
  545 | n_settings.verbose>0) i_info("FTS Xapian: Optimize - Closing DB %s",s);
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
      |                             |                                    |
      |                             |                                    char*
      |                             std::string {aka std::__cxx11::basic_string<char>}
```