### PR TITLE
Fix printf warnings in 1.8.4

### DIFF
--- a/src/fts-backend-xapian-functions.cpp
+++ b/src/fts-backend-xapian-functions.cpp
@@ -789,11 +789,11 @@ class XDocsWriter
 		}
                 catch(Xapian::DatabaseLockError e)
                 {
-                        syslog(LOG_WARNING,"%sCan't lock the DB : %s - %s",title,e.get_type(),e.get_msg());
+                        syslog(LOG_WARNING,"%sCan't lock the DB : %s - %s",title,e.get_type(),e.get_msg().c_str());
 		}
                 catch(Xapian::Error e)
                 {
-			syslog(LOG_WARNING,"%sCan't open the DB RW : %s - %s",title,e.get_type(),e.get_msg());
+			syslog(LOG_WARNING,"%sCan't open the DB RW : %s - %s",title,e.get_type(),e.get_msg().c_str());
                 }
 		return false;
 	}
@@ -881,7 +881,7 @@ class XDocsWriter
                         	}
                         	catch(Xapian::Error e)
                         	{
-					syslog(LOG_ERR,"%sCan't commit DB1 : %s - %s",title,e.get_type(),e.get_msg());
+					syslog(LOG_ERR,"%sCan't commit DB1 : %s - %s",title,e.get_type(),e.get_msg().c_str());
                         	}
                         	catch(std::exception e)
                         	{
@@ -990,7 +990,7 @@ class XDocsWriter
                         	        	}
 						catch(Xapian::Error e)
                                	                {
-                               	                 	syslog(LOG_ERR,"%sCan't write doc1 %s : %s - %s",title,doc->getDocSummary().c_str(),e.get_type(),e.get_msg());
+                               	                 	syslog(LOG_ERR,"%sCan't write doc1 %s : %s - %s",title,doc->getDocSummary().c_str(),e.get_type(),e.get_msg().c_str());
                                	                }
                                	                catch(std::exception e)
                                	                {


### PR DESCRIPTION
### Fix printf warnings in 1.8.4

`Xapian::Error::get_msg()` returns a `std::string`, so these need `.c_str()` on them to pass as `%s`.

Errors:
```
In file included from fts-backend-xapian.cpp:75:
fts-backend-xapian-functions.cpp: In member function 'bool XDocsWriter::checkDB()':
fts-backend-xapian-functions.cpp:792:73: warning: format '%s' expects argument of type 'char*', but argument 5 has type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} [-Wformat=]
  792 |             syslog(LOG_WARNING,"%sCan't lock the DB : %s - %s",title,e.get_type(),e.get_msg());
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                   |                                         |
      |                   |                                         char*
      |                   const std::string {aka const std::__cxx11::basic_string<char>}

fts-backend-xapian-functions.cpp:796:76: warning: format '%s' expects argument of type 'char*', but argument 5 has type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} [-Wformat=]
  796 |          syslog(LOG_WARNING,"%sCan't open the DB RW : %s - %s",title,e.get_type(),e.get_msg());
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                |                                            |
      |                |                                            char*
      |                const std::string {aka const std::__cxx11::basic_string<char>}

fts-backend-xapian-functions.cpp: In member function 'long int XDocsWriter::checkMemory()':
fts-backend-xapian-functions.cpp:884:84: warning: format '%s' expects argument of type 'char*', but argument 5 has type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} [-Wformat=]
  884 |                  syslog(LOG_ERR,"%sCan't commit DB1 : %s - %s",title,e.get_type(),e.get_msg());
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                        |                                    |
      |                        |                                    char*
      |                        const std::string {aka const std::__cxx11::basic_string<char>}

fts-backend-xapian-functions.cpp: In member function 'void XDocsWriter::worker()':
fts-backend-xapian-functions.cpp:993:103: warning: format '%s' expects argument of type 'char*', but argument 6 has type 'const std::string' {aka 'const std::__cxx11::basic_string<char>'} [-Wformat=]
  993 |               syslog(LOG_ERR,"%sCan't write doc1 %s : %s - %s",title,doc->getDocSummary().c_str(),e.get_type(),e.get_msg());
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                     |                                       |
      |                     |                                       char*
      |                     const std::string {aka const std::__cxx11::basic_string<char>}

```